### PR TITLE
Fix compatibility with Ansible 1.7.2+

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,8 +1,16 @@
 ---
 
+- name: packages > Manage packages (force option)
+  apt:
+    name:  "{{ item.name }}"
+    force: "{{ item.force }}"
+    state: "{{ item.state|default('present') }}"
+  with_items: elao_apt_packages
+  when: item.force is defined
+
 - name: packages > Manage packages
   apt:
     name:  "{{ item.name }}"
-    force: "{{ item.force|default(omit) }}"
     state: "{{ item.state|default('present') }}"
   with_items: elao_apt_packages
+  when: item.force is not defined


### PR DESCRIPTION
Filter "default(omit)" come with Ansible 1.8.

A dirty way to keep your feature and preserve compatibility with Ansible 1.7.2. for this 1.0 release.
