### PR TITLE
Permits customization of apt cache valid time

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ None
 | `elao_apt_repositories` | []       | Array | Collection of repositories |
 | `elao_apt_preferences`  | []       | Array | Collection of preferences  |
 | `elao_apt_packages`     | []       | Array | Collection of packages     |
+| `elao_apt_update_valid_time` | 180 | Int   | Permitted age of apt cache, in seconds |
 
 ### Example
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,4 @@ elao_apt_packages: []
 # Update / Upgrade
 elao_apt_update:  "{{ elao.update|default(false) if (elao is defined) else false }}"
 elao_apt_upgrade: "{{ elao.upgrade|default(false) if (elao is defined) else false }}"
+elao_apt_update_valid_time: 180

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -3,4 +3,4 @@
 - name: update > Update cache
   apt:
     update_cache:     yes
-    cache_valid_time: 180
+    cache_valid_time: "{{ elao_apt_update_valid_time }}"


### PR DESCRIPTION
Adds a new default role var `elao_apt_update_valid_time`, with default
value of 180, to enable overriding the default max age of 180s for the
apt cache. Preserves existing role behavior by default, so the change is
entirely optional and opt-in.

Closes #5.